### PR TITLE
Create config directory if it doesn't exist

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@ mod versions;
 use ambient_toml::AmbientToml;
 use clap::Parser;
 use colored::Colorize;
-use environment::{runtimes_dir, settings_path, Os};
+use environment::{app_dir, runtimes_dir, settings_path, Os};
 use semver::VersionReq;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
@@ -90,6 +90,7 @@ impl Settings {
         )?)
     }
     fn save(&self) -> anyhow::Result<()> {
+        std::fs::create_dir_all(app_dir()?.config_dir())?;
         std::fs::write(settings_path()?, serde_json::to_string_pretty(self)?)?;
         Ok(())
     }
@@ -249,7 +250,7 @@ async fn runtime_exec(mut settings: Settings, args: Vec<String>) -> anyhow::Resu
 async fn main() -> anyhow::Result<()> {
     env_logger::init();
 
-    let settings = if settings_path()?.exists() {
+    let settings = if settings_path()?.try_exists()? {
         Settings::load()?
     } else {
         Settings::default()


### PR DESCRIPTION
Running `ambient` currently only works if the directory for the settings already exists. If it doesn't you get an unclear error message when the CLI tries to save new settings:

```bash
$ ambient
No default runtime version set, installing latest stable version
Runtime version 0.3.0-nightly-2023-09-16 is already installed
Error: No such file or directory (os error 2)
```

This PR creates the config directory for the CLI if it doesn't already exist. Also, I changed `exists` to `try_exists` so that it errors right away if the existence of the config directory can't be determined (`exists` returns `false` if it doesn't know if a directory exists, while `try_exists` returns `Err(...)`).

Also, just to note: `Settings::save` saves the settings synchronously, but gets called in an `async` context. As such, the async executor will get blocked while the settings are being saved, and won't be able to do other things while the settings are being saved. This isn't a problem currently - none of the codepaths that call `Settings::save` are doing something else in parallel anyways, but I'm not sure if this was intentional.